### PR TITLE
Feat/34 add percentage donut chart

### DIFF
--- a/client/src/components/user/dashbaord/charts/CategoryWiseExpensesChart.tsx
+++ b/client/src/components/user/dashbaord/charts/CategoryWiseExpensesChart.tsx
@@ -195,6 +195,8 @@ const CategoryWiseExpensesChart: React.FC<CategoryWiseDataPropTypes> = ({
     MiscellaneousExpenses,
   ]);
 
+  const total = categoryData.reduce((acc, { value }) => acc + (value ?? 0), 0);
+
   return (
     <div className="flex items-center p-0 py-4 md:p-4 bg-white rounded-lg shadow-sm flex-col max-w-full w-full">
       <h2 className="text-lg md:text-left text-center font-semibold mb-4">
@@ -216,7 +218,7 @@ const CategoryWiseExpensesChart: React.FC<CategoryWiseDataPropTypes> = ({
                     className="w-4 h-4 rounded-[2px]"
                     style={{ backgroundColor: color }}
                   ></div>
-                  <span>{label}</span>
+                  <span>{`${label}: ${((value ?? 0) / total * 100).toFixed(1)}%`}</span>
                 </div>
               )}
             </React.Fragment>

--- a/client/src/components/user/dashbaord/charts/CategoryWiseExpensesChart.tsx
+++ b/client/src/components/user/dashbaord/charts/CategoryWiseExpensesChart.tsx
@@ -215,10 +215,10 @@ const CategoryWiseExpensesChart: React.FC<CategoryWiseDataPropTypes> = ({
               {value !== 0 && (
                 <div className="flex items-center space-x-2">
                   <div
-                    className="w-4 h-4 rounded-[2px]"
+                    className="w-8 h-8 rounded-[2px] flex items-center justify-center text-white font-semibold text-sm"
                     style={{ backgroundColor: color }}
-                  ></div>
-                  <span>{`${label}: ${((value ?? 0) / total * 100).toFixed(1)}%`}</span>
+                  >{`${(((value ?? 0) / total) * 100).toFixed(0)}%`}</div>
+                  <span>{label}</span>
                 </div>
               )}
             </React.Fragment>


### PR DESCRIPTION
I have added percentage values in legend markers and created a new branch named feat/34-add-percentage-donut-chart to create a new PR. The result is below: closes #34 

![Screenshot 2024-11-12 at 1 16 55 AM](https://github.com/user-attachments/assets/a8e4f819-00e4-4381-8ca4-a4ef767719a0)
