### PR TITLE
fix(pocketMoney): Add Money button does nothing

### DIFF
--- a/client/src/features/pocketMoney/components/AddPocketMoneyForm.tsx
+++ b/client/src/features/pocketMoney/components/AddPocketMoneyForm.tsx
@@ -20,7 +20,7 @@ export default function AddPocketMoneyForm() {
   } = useForm<AddPocketMoneyForm>({
     resolver: zodResolver(addPocketMoneySchema),
     mode: 'onTouched',
-    defaultValues: { amount: '', source: '', date: '' },
+    defaultValues: { amount: '', source: '', date: getTodayDate() },
   });
 
   const onSubmit = handleSubmit(async (values) => {
@@ -35,7 +35,7 @@ export default function AddPocketMoneyForm() {
       success: 'Pocket money added!',
       error: 'Something went wrong.',
     });
-    reset({ amount: '', source: '', date: '' });
+    reset({ amount: '', source: '', date: getTodayDate() });
   });
 
   return (


### PR DESCRIPTION
`defaultValues.date` was an empty string. The Zod schema requires `dd-mm-yyyy`, so RHF's `handleSubmit` failed validation **before** the inner handler could inject `getTodayDate()`. The form has no UI for the date field, so `errors.date` was silently set and clicking "Add Money" appeared to do nothing.

Seed `defaultValues.date` (and the post-success `reset()`) with `getTodayDate()`. Handler still re-injects today on submit, so a form left open past midnight still posts the correct date.

## Test plan
- [ ] Add Money page → enter amount + source → click Add Money → toast fires, row appears in history.
- [ ] Without leaving the page, add another → second submit also works.
